### PR TITLE
PR 8 : feat(lab-02): implement ticket detail ownership protection

### DIFF
--- a/server/src/routes/ticket.routes.ts
+++ b/server/src/routes/ticket.routes.ts
@@ -158,3 +158,122 @@ ticketRouter.post(
     }
   }
 );
+
+const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// GET /api/tickets/:id - Retrieve owned ticket details with attachments (Issue #25)
+ticketRouter.get(
+  "/tickets/:id",
+  requesterContextMiddleware,
+  async (req: AuthenticatedRequesterRequest, res: Response): Promise<void> => {
+    const ticketId = req.params.id;
+
+    if (!UUID_REGEX.test(ticketId)) {
+      res.status(400).json({
+        error: {
+          code: "INVALID_TICKET_ID",
+          message: "Ticket ID must be a valid UUID.",
+        },
+      });
+      return;
+    }
+
+    const requesterId = req.requesterId!;
+
+    try {
+      const prisma = getPrisma();
+      const ticket = await prisma.ticket.findFirst({
+        where: {
+          id: ticketId,
+          requesterId, // Enforces ownership strictly at the database query level
+        },
+        include: {
+          requester: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+          category: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          relatedSystem: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          attachments: {
+            orderBy: {
+              uploadedAt: "asc",
+            },
+            select: {
+              id: true,
+              fileName: true,
+              fileSize: true,
+              mimeType: true,
+              uploadedAt: true,
+              removedAt: true,
+              removalReason: true,
+            },
+          },
+        },
+      });
+
+      if (!ticket) {
+        res.status(404).json({
+          error: {
+            code: "TICKET_NOT_FOUND",
+            message: "Ticket not found.",
+          },
+        });
+        return;
+      }
+
+      res.status(200).json({
+        id: ticket.id,
+        ticketNumber: ticket.ticketNumber,
+        requester: {
+          id: ticket.requester.id,
+          name: ticket.requester.name,
+          email: ticket.requester.email,
+        },
+        category: {
+          id: ticket.category.id,
+          name: ticket.category.name,
+        },
+        relatedSystem: {
+          id: ticket.relatedSystem.id,
+          name: ticket.relatedSystem.name,
+        },
+        requestedPriority: ticket.requestedPriority,
+        currentStatus: ticket.currentStatus,
+        summary: ticket.summary,
+        description: ticket.description,
+        createdAt: ticket.createdAt,
+        updatedAt: ticket.updatedAt,
+        attachments: ticket.attachments.map((att) => ({
+          id: att.id,
+          fileName: att.fileName,
+          fileSize: att.fileSize,
+          mimeType: att.mimeType,
+          uploadedAt: att.uploadedAt,
+          removedAt: att.removedAt,
+          removalReason: att.removalReason,
+          isRemoved: att.removedAt !== null,
+        })),
+      });
+    } catch (error) {
+      res.status(500).json({
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to retrieve ticket details.",
+        },
+      });
+    }
+  }
+);

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import app from "../../src/app.js";
+
+describe("Issue #25: Ticket Detail API & Ownership Protection (GET /api/tickets/:id)", () => {
+  const aliceHeader = { "X-Requester-Id": "1" }; // Alice Smith (Owner)
+  const bobHeader = { "X-Requester-Id": "2" };   // Bob Jones (Non-Owner)
+
+  let aliceTicketId: string;
+
+  beforeAll(async () => {
+    // Create a ticket owned by Alice Smith (Requester 1) to test ownership and detail retrieval
+    const res = await request(app)
+      .post("/api/tickets")
+      .set(aliceHeader)
+      .send({
+        categoryId: 1,
+        relatedSystemId: 1,
+        requestedPriority: "HIGH",
+        summary: "Detail Test Ticket Summary",
+        description: "Detailed description for testing Ticket Detail API endpoint.",
+      });
+
+    expect(res.status).toBe(201);
+    aliceTicketId = res.body.id;
+  });
+
+  describe("Requester Context Header Validation", () => {
+    it("API-01 / BR-09: Returns HTTP 400 Bad Request when X-Requester-Id header is missing", async () => {
+      const res = await request(app).get(`/api/tickets/${aliceTicketId}`);
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({
+        error: {
+          code: "INVALID_REQUESTER_HEADER",
+          message: "Header X-Requester-Id must be a positive integer.",
+        },
+      });
+    });
+
+    it("API-02 / BR-09: Returns HTTP 400 Bad Request when X-Requester-Id header is malformed, non-numeric, or <= 0", async () => {
+      const resInvalid = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set("X-Requester-Id", "abc");
+      expect(resInvalid.status).toBe(400);
+      expect(resInvalid.body.error.code).toBe("INVALID_REQUESTER_HEADER");
+
+      const resZero = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set("X-Requester-Id", "0");
+      expect(resZero.status).toBe(400);
+      expect(resZero.body.error.code).toBe("INVALID_REQUESTER_HEADER");
+
+      const resNeg = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set("X-Requester-Id", "-5");
+      expect(resNeg.status).toBe(400);
+      expect(resNeg.body.error.code).toBe("INVALID_REQUESTER_HEADER");
+    });
+
+    it("BR-09: Returns HTTP 403 Forbidden when X-Requester-Id specifies unknown or inactive requester", async () => {
+      // Inactive Requester: Eve Adams (id=5)
+      const resInactive = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set("X-Requester-Id", "5");
+      expect(resInactive.status).toBe(403);
+      expect(resInactive.body).toEqual({
+        error: {
+          code: "FORBIDDEN_REQUESTER",
+          message: "Specified requester is unknown or inactive.",
+        },
+      });
+
+      // Unknown Requester ID
+      const resUnknown = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set("X-Requester-Id", "9999");
+      expect(resUnknown.status).toBe(403);
+      expect(resUnknown.body).toEqual({
+        error: {
+          code: "FORBIDDEN_REQUESTER",
+          message: "Specified requester is unknown or inactive.",
+        },
+      });
+    });
+  });
+
+  describe("Path Parameter Validation", () => {
+    it("Returns HTTP 400 Bad Request when ticket :id path parameter is not a valid UUID", async () => {
+      const res = await request(app)
+        .get("/api/tickets/not-a-valid-uuid")
+        .set(aliceHeader);
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({
+        error: {
+          code: "INVALID_TICKET_ID",
+          message: "Ticket ID must be a valid UUID.",
+        },
+      });
+    });
+  });
+
+  describe("Ownership Protection & Resource Existence (BR-04, BR-05, AC-03, API-14)", () => {
+    it("API-14 / BR-04 / BR-05 / AC-03: Returns HTTP 404 Not Found when non-owner requests another requester's ticket", async () => {
+      // Bob Jones (Requester 2) attempts to access Alice Smith's (Requester 1) ticket
+      const res = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set(bobHeader);
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({
+        error: {
+          code: "TICKET_NOT_FOUND",
+          message: "Ticket not found.",
+        },
+      });
+    });
+
+    it("Returns HTTP 404 Not Found when ticket UUID does not exist", async () => {
+      const nonExistentUuid = "00000000-0000-0000-0000-000000000000";
+      const res = await request(app)
+        .get(`/api/tickets/${nonExistentUuid}`)
+        .set(aliceHeader);
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({
+        error: {
+          code: "TICKET_NOT_FOUND",
+          message: "Ticket not found.",
+        },
+      });
+    });
+
+    it("Verifies non-owner 404 response is identical to non-existent ticket 404 response (zero IDOR disclosure)", async () => {
+      const nonOwnerRes = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set(bobHeader);
+
+      const nonExistentRes = await request(app)
+        .get("/api/tickets/00000000-0000-0000-0000-000000000000")
+        .set(aliceHeader);
+
+      expect(nonOwnerRes.status).toBe(404);
+      expect(nonExistentRes.status).toBe(404);
+      expect(nonOwnerRes.body).toEqual(nonExistentRes.body);
+    });
+  });
+
+  describe("Ticket Detail Retrieval Success (FR-06)", () => {
+    it("Returns HTTP 200 OK with complete ticket detail and nested relations for owning requester", async () => {
+      const res = await request(app)
+        .get(`/api/tickets/${aliceTicketId}`)
+        .set(aliceHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(aliceTicketId);
+      expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+      expect(res.body.summary).toBe("Detail Test Ticket Summary");
+      expect(res.body.description).toBe("Detailed description for testing Ticket Detail API endpoint.");
+      expect(res.body.requestedPriority).toBe("HIGH");
+      expect(res.body.currentStatus).toBe("NEW");
+
+      // Verify nested relations
+      expect(res.body.requester).toEqual({
+        id: 1,
+        name: "Alice Smith",
+        email: "alice@example.com",
+      });
+      expect(res.body.category).toEqual({
+        id: 1,
+        name: "Account and Access",
+      });
+      expect(res.body.relatedSystem).toEqual({
+        id: 1,
+        name: "Email",
+      });
+
+      // Verify attachments array metadata
+      expect(Array.isArray(res.body.attachments)).toBe(true);
+      expect(res.body.attachments).toEqual([]);
+      expect(res.body).toHaveProperty("createdAt");
+      expect(res.body).toHaveProperty("updatedAt");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements GitHub Issue #25: Ticket Detail API and Ownership Protection.

## Implemented

- Added `GET /api/tickets/:id`
- Reused `X-Requester-Id` requester context middleware
- Added UUID validation for ticket IDs
- Enforced ticket ownership at the database query level
- Returns `200 OK` for the ticket owner
- Returns the same `404 TICKET_NOT_FOUND` response for non-owner and non-existent tickets
- Added requester, category, related system, and attachment metadata to the response
- Added `isRemoved` attachment status

## Tests

- Added Ticket Detail API integration tests
- Owner access
- Non-owner access
- Non-existent ticket
- IDOR indistinguishability
- Invalid/missing requester context
- Invalid ticket UUID
- Full test suite: **36/36 tests passed**

## Scope

- Backend/API and tests only
- No frontend changes
- No Prisma schema/migration changes for Issue #25
- No seed or documentation changes
- No Lab 3 authentication introduced

Closes #25