### PR TITLE
PR 10 : feat(lab-02): implement requester selection and context

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,27 +12,29 @@ import {
 type UiState = "idle" | "loading" | "success" | "error";
 
 export default function App() {
-  // Lab 1 state
+  // 1. Lab 1 state (Top level of App component)
   const [lab1State, setLab1State] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
   const [lab1ErrorMessage, setLab1ErrorMessage] = useState<string>("");
 
-  // Lab 2 Requester Context & Selector state
+  // 2. Lab 2 Requester Context & Selector state (Top level of App component)
   const [requestersLoading, setRequestersLoading] = useState<boolean>(true);
   const [requestersError, setRequestersError] = useState<string | null>(null);
   const [activeRequesters, setActiveRequesters] = useState<Requester[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [currentRequester, setCurrentRequester] = useState<Requester | null>(null);
-  const [isSelecting, setIsSelecting] = useState<boolean>(false);
+  const [isSelecting, setIsSelecting] = useState<boolean>(true);
 
-  // Requester ticket data state
+  // 3. Requester ticket data state (Top level of App component)
   const [tickets, setTickets] = useState<any[]>([]);
   const [ticketsLoading, setTicketsLoading] = useState<boolean>(false);
 
+  // 4. Startup Effect (Top level of App component)
   useEffect(() => {
     loadRequestersAndRestoreContext();
   }, []);
 
+  // Normal helper functions (No React Hooks declared inside helper functions)
   async function loadRequestersAndRestoreContext() {
     setRequestersLoading(true);
     setRequestersError(null);
@@ -43,7 +45,7 @@ export default function App() {
 
       const storedId = getSelectedRequesterId();
 
-      // Validate stored ID against active requesters
+      // Validate stored ID against active requesters list
       if (storedId) {
         const found = requesters.find((r) => String(r.id) === String(storedId) && r.isActive !== false);
         if (found) {
@@ -119,7 +121,10 @@ export default function App() {
     return (
       <div className="container py-5" style={{ maxWidth: 640 }}>
         <header className="mb-4">
-          <h1 className="h3 text-success fw-bold">Select Development Requester</h1>
+          <h1 className="h3">
+            TokTickIT <span className="text-success">IT Service Desk</span>
+          </h1>
+          <h2 className="h4 text-success fw-bold mt-3">Select Development Requester</h2>
           <p className="text-muted small">
             Select a Development Requester for Lab 2 testing context. This selector attaches the{" "}
             <code>X-Requester-Id</code> header to API requests (this is for development testing context, not user authentication).
@@ -198,6 +203,35 @@ export default function App() {
             </div>
           </form>
         )}
+
+        {/* Lab 1 System Check Panel */}
+        <section className="border-top pt-4 mt-5">
+          <button className="btn btn-success mb-3" onClick={handleCheckSystem} disabled={lab1State === "loading"}>
+            {lab1State === "loading" ? "Loading…" : "Check System"}
+          </button>
+
+          {lab1State === "success" && (
+            <div className="mt-2">
+              <p className="fw-bold mb-2">
+                System Status: <span className="text-success">Online</span>
+              </p>
+              <ol className="list-group list-group-numbered">
+                {categories.map((cat) => (
+                  <li key={cat.id} className="list-group-item">
+                    {cat.name}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {lab1State === "error" && (
+            <div className="mt-2">
+              <p className="fw-bold text-danger mb-1">System Status: Offline</p>
+              <p className="text-muted">{lab1ErrorMessage || "Unable to connect to the server."}</p>
+            </div>
+          )}
+        </section>
       </div>
     );
   }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,43 +1,262 @@
-import { useState } from "react";
-import { checkSystem, Category } from "./api.js";
+import { useState, useEffect } from "react";
+import {
+  checkSystem,
+  Category,
+  Requester,
+  fetchActiveRequesters,
+  getSelectedRequesterId,
+  setSelectedRequesterId,
+  fetchMyTickets,
+} from "./api.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
 
 export default function App() {
-  const [state, setState] = useState<UiState>("idle");
+  // Lab 1 state
+  const [lab1State, setLab1State] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
-  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [lab1ErrorMessage, setLab1ErrorMessage] = useState<string>("");
 
-  async function handleCheck() {
-    setState("loading");
-    setErrorMessage("");
+  // Lab 2 Requester Context & Selector state
+  const [requestersLoading, setRequestersLoading] = useState<boolean>(true);
+  const [requestersError, setRequestersError] = useState<string | null>(null);
+  const [activeRequesters, setActiveRequesters] = useState<Requester[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [currentRequester, setCurrentRequester] = useState<Requester | null>(null);
+  const [isSelecting, setIsSelecting] = useState<boolean>(false);
+
+  // Requester ticket data state
+  const [tickets, setTickets] = useState<any[]>([]);
+  const [ticketsLoading, setTicketsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    loadRequestersAndRestoreContext();
+  }, []);
+
+  async function loadRequestersAndRestoreContext() {
+    setRequestersLoading(true);
+    setRequestersError(null);
+
     try {
-      const res = await checkSystem();
-      setCategories(res.categories);
-      setState("success");
+      const requesters = await fetchActiveRequesters();
+      setActiveRequesters(requesters);
+
+      const storedId = getSelectedRequesterId();
+
+      // Validate stored ID against active requesters
+      if (storedId) {
+        const found = requesters.find((r) => String(r.id) === String(storedId) && r.isActive !== false);
+        if (found) {
+          setCurrentRequester(found);
+          setIsSelecting(false);
+          loadTicketsForRequester(String(found.id));
+        } else {
+          // Invalid, unknown, or inactive stored ID -> require selection
+          setSelectedRequesterId(null);
+          setCurrentRequester(null);
+          setIsSelecting(true);
+        }
+      } else {
+        setIsSelecting(true);
+      }
     } catch (err: any) {
-      setErrorMessage(err?.message || "Unable to connect to the server. Please check your connection and try again.");
-      setState("error");
+      setRequestersError(err?.message || "Unable to load requesters. Please check your connection.");
+      setIsSelecting(true);
+    } finally {
+      setRequestersLoading(false);
     }
   }
 
-  return (
-    <div className="container py-5" style={{ maxWidth: 640 }}>
-      <h1 className="h3 mb-4">
-        TokTickIT <span className="text-success">IT Service Desk</span>
-      </h1>
+  async function loadTicketsForRequester(requesterId: string) {
+    setTicketsLoading(true);
+    try {
+      const res = await fetchMyTickets();
+      setTickets(res?.data || []);
+    } catch (err) {
+      setTickets([]);
+    } finally {
+      setTicketsLoading(false);
+    }
+  }
 
-      <button className="btn btn-success mb-4" onClick={handleCheck} disabled={state === "loading"}>
-        {state === "loading" ? "Loading…" : "Check System"}
-      </button>
+  function handleSelectRequester(id: string) {
+    setSelectedId(id);
+  }
 
-      {state === "success" && (
-        <div className="mt-3">
-          <p className="fw-bold mb-2">
-            System Status: <span className="text-success">Online</span>
+  function handleContinue() {
+    if (!selectedId) return;
+
+    const chosen = activeRequesters.find((r) => String(r.id) === String(selectedId));
+    if (chosen) {
+      setSelectedRequesterId(String(chosen.id));
+      setCurrentRequester(chosen);
+      setIsSelecting(false);
+      loadTicketsForRequester(String(chosen.id));
+    }
+  }
+
+  function handleChangeRequester() {
+    setIsSelecting(true);
+    setSelectedId(currentRequester ? String(currentRequester.id) : null);
+  }
+
+  // Lab 1 handler
+  async function handleCheckSystem() {
+    setLab1State("loading");
+    setLab1ErrorMessage("");
+    try {
+      const res = await checkSystem();
+      setCategories(res.categories);
+      setLab1State("success");
+    } catch (err: any) {
+      setLab1ErrorMessage(err?.message || "Unable to connect to the server. Please check your connection and try again.");
+      setLab1State("error");
+    }
+  }
+
+  // Render Requester Selection View
+  if (isSelecting) {
+    return (
+      <div className="container py-5" style={{ maxWidth: 640 }}>
+        <header className="mb-4">
+          <h1 className="h3 text-success fw-bold">Select Development Requester</h1>
+          <p className="text-muted small">
+            Select a Development Requester for Lab 2 testing context. This selector attaches the{" "}
+            <code>X-Requester-Id</code> header to API requests (this is for development testing context, not user authentication).
           </p>
-          <div>
-            <p className="fw-semibold mb-2">Supported Request Categories:</p>
+        </header>
+
+        {requestersLoading && (
+          <div className="alert alert-info" role="status">
+            Loading active requesters…
+          </div>
+        )}
+
+        {requestersError && (
+          <div className="alert alert-danger" role="alert">
+            {requestersError}
+          </div>
+        )}
+
+        {!requestersLoading && !requestersError && activeRequesters.length === 0 && (
+          <div className="alert alert-warning" role="alert">
+            No active requesters available.
+          </div>
+        )}
+
+        {!requestersLoading && !requestersError && activeRequesters.length > 0 && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleContinue();
+            }}
+          >
+            <div className="card mb-4 shadow-sm">
+              <div className="card-header bg-light fw-semibold">Available Development Requesters</div>
+              <div className="list-group list-group-flush">
+                {activeRequesters.map((req) => {
+                  const isChecked = selectedId === String(req.id);
+                  return (
+                    <label
+                      key={req.id}
+                      className={`list-group-item list-group-item-action d-flex align-items-center justify-content-between p-3 ${
+                        isChecked ? "active bg-success text-white" : ""
+                      }`}
+                      style={{ cursor: "pointer" }}
+                    >
+                      <div className="d-flex align-items-center">
+                        <input
+                          type="radio"
+                          name="requester"
+                          id={`requester-${req.id}`}
+                          aria-label={req.name}
+                          value={req.id}
+                          checked={isChecked}
+                          onChange={() => handleSelectRequester(String(req.id))}
+                          className="form-check-input me-3"
+                        />
+                        <div>
+                          <div className="fw-bold">{req.name}</div>
+                          <div className={`small ${isChecked ? "text-white-50" : "text-muted"}`}>{req.email}</div>
+                        </div>
+                      </div>
+                      <span className={`badge ${isChecked ? "bg-light text-dark" : "bg-secondary"}`}>ID: {req.id}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="d-grid">
+              <button
+                type="submit"
+                className="btn btn-success btn-lg"
+                disabled={!selectedId}
+              >
+                Continue
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    );
+  }
+
+  // Render Application Shell with Selected Requester Context
+  return (
+    <div className="container py-5" style={{ maxWidth: 800 }}>
+      {/* App Shell Header displaying Current Requester Identity & Change Requester button */}
+      <nav className="navbar navbar-light bg-light rounded p-3 mb-4 d-flex align-items-center justify-content-between border">
+        <div>
+          <span className="text-muted me-2">Current Requester:</span>
+          <span className="fw-bold text-success fs-5">{currentRequester?.name}</span>
+          <span className="badge bg-secondary ms-2">ID: {currentRequester?.id}</span>
+        </div>
+        <button className="btn btn-outline-secondary btn-sm" onClick={handleChangeRequester}>
+          Change Requester
+        </button>
+      </nav>
+
+      {/* Main Application Shell Content */}
+      <header className="mb-4">
+        <h1 className="h3">
+          TokTickIT <span className="text-success">IT Service Desk</span>
+        </h1>
+      </header>
+
+      {/* Requester-specific ticket data view */}
+      <section className="mb-5">
+        <h2 className="h5 mb-3 fw-bold">My Tickets</h2>
+        {ticketsLoading ? (
+          <div className="text-muted">Loading tickets…</div>
+        ) : tickets.length > 0 ? (
+          <ul className="list-group">
+            {tickets.map((t) => (
+              <li key={t.id} className="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                  <div className="fw-bold">{t.summary}</div>
+                  <div className="small text-muted">{t.ticketNumber}</div>
+                </div>
+                <span className="badge bg-primary">{t.requestedPriority}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="text-muted italic">No tickets found.</div>
+        )}
+      </section>
+
+      {/* Lab 1 System Check Panel */}
+      <section className="border-top pt-4">
+        <button className="btn btn-success mb-3" onClick={handleCheckSystem} disabled={lab1State === "loading"}>
+          {lab1State === "loading" ? "Loading…" : "Check System"}
+        </button>
+
+        {lab1State === "success" && (
+          <div className="mt-2">
+            <p className="fw-bold mb-2">
+              System Status: <span className="text-success">Online</span>
+            </p>
             <ol className="list-group list-group-numbered">
               {categories.map((cat) => (
                 <li key={cat.id} className="list-group-item">
@@ -46,15 +265,15 @@ export default function App() {
               ))}
             </ol>
           </div>
-        </div>
-      )}
+        )}
 
-      {state === "error" && (
-        <div className="mt-3">
-          <p className="fw-bold text-danger mb-1">System Status: Offline</p>
-          <p className="text-muted">{errorMessage || "Unable to connect to the server. Please check your connection and try again."}</p>
-        </div>
-      )}
+        {lab1State === "error" && (
+          <div className="mt-2">
+            <p className="fw-bold text-danger mb-1">System Status: Offline</p>
+            <p className="text-muted">{lab1ErrorMessage || "Unable to connect to the server."}</p>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   checkSystem,
   Category,
@@ -10,6 +10,7 @@ import {
 } from "./api.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
+type NavigationTab = "my-tickets" | "create-ticket";
 
 export default function App() {
   // 1. Lab 1 state (Top level of App component)
@@ -25,11 +26,15 @@ export default function App() {
   const [currentRequester, setCurrentRequester] = useState<Requester | null>(null);
   const [isSelecting, setIsSelecting] = useState<boolean>(true);
 
-  // 3. Requester ticket data state (Top level of App component)
+  // 3. Navigation Tab state (Top level of App component)
+  const [activeTab, setActiveTab] = useState<NavigationTab>("my-tickets");
+
+  // 4. Requester ticket data state & request tracker ref (Top level of App component)
   const [tickets, setTickets] = useState<any[]>([]);
   const [ticketsLoading, setTicketsLoading] = useState<boolean>(false);
+  const latestTicketRequestIdRef = useRef<number>(0);
 
-  // 4. Startup Effect (Top level of App component)
+  // 5. Startup Effect (Top level of App component)
   useEffect(() => {
     loadRequestersAndRestoreContext();
   }, []);
@@ -69,15 +74,24 @@ export default function App() {
     }
   }
 
+  // Explicit requester context passed down with concurrency race protection
   async function loadTicketsForRequester(requesterId: string) {
+    const requestId = ++latestTicketRequestIdRef.current;
     setTicketsLoading(true);
     try {
-      const res = await fetchMyTickets();
-      setTickets(res?.data || []);
+      const res = await fetchMyTickets(requesterId);
+      // Ignore response if a newer request was initiated
+      if (requestId === latestTicketRequestIdRef.current) {
+        setTickets(res?.data || []);
+      }
     } catch (err) {
-      setTickets([]);
+      if (requestId === latestTicketRequestIdRef.current) {
+        setTickets([]);
+      }
     } finally {
-      setTicketsLoading(false);
+      if (requestId === latestTicketRequestIdRef.current) {
+        setTicketsLoading(false);
+      }
     }
   }
 
@@ -236,7 +250,7 @@ export default function App() {
     );
   }
 
-  // Render Application Shell with Selected Requester Context
+  // Render Application Shell with Selected Requester Context & Navigation Tabs
   return (
     <div className="container py-5" style={{ maxWidth: 800 }}>
       {/* App Shell Header displaying Current Requester Identity & Change Requester button */}
@@ -251,34 +265,70 @@ export default function App() {
         </button>
       </nav>
 
-      {/* Main Application Shell Content */}
+      {/* Main Application Shell Title & Logo */}
       <header className="mb-4">
         <h1 className="h3">
           TokTickIT <span className="text-success">IT Service Desk</span>
         </h1>
       </header>
 
-      {/* Requester-specific ticket data view */}
-      <section className="mb-5">
-        <h2 className="h5 mb-3 fw-bold">My Tickets</h2>
-        {ticketsLoading ? (
-          <div className="text-muted">Loading tickets…</div>
-        ) : tickets.length > 0 ? (
-          <ul className="list-group">
-            {tickets.map((t) => (
-              <li key={t.id} className="list-group-item d-flex justify-content-between align-items-center">
-                <div>
-                  <div className="fw-bold">{t.summary}</div>
-                  <div className="small text-muted">{t.ticketNumber}</div>
-                </div>
-                <span className="badge bg-primary">{t.requestedPriority}</span>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div className="text-muted italic">No tickets found.</div>
-        )}
-      </section>
+      {/* Application Shell Navigation Tabs (docs/lab-02/ui-spec.md §3.1) */}
+      <ul className="nav nav-tabs mb-4" role="tablist">
+        <li className="nav-item">
+          <button
+            type="button"
+            className={`nav-link ${activeTab === "my-tickets" ? "active fw-bold text-success" : "text-secondary"}`}
+            aria-current={activeTab === "my-tickets" ? "page" : undefined}
+            onClick={() => setActiveTab("my-tickets")}
+          >
+            My Tickets
+          </button>
+        </li>
+        <li className="nav-item">
+          <button
+            type="button"
+            className={`nav-link ${activeTab === "create-ticket" ? "active fw-bold text-success" : "text-secondary"}`}
+            aria-current={activeTab === "create-ticket" ? "page" : undefined}
+            onClick={() => setActiveTab("create-ticket")}
+          >
+            Create Ticket
+          </button>
+        </li>
+      </ul>
+
+      {/* Tab Content 1: My Tickets Screen View */}
+      {activeTab === "my-tickets" && (
+        <section className="mb-5">
+          <h2 className="h5 mb-3 fw-bold">My Tickets</h2>
+          {ticketsLoading ? (
+            <div className="text-muted">Loading tickets…</div>
+          ) : tickets.length > 0 ? (
+            <ul className="list-group">
+              {tickets.map((t) => (
+                <li key={t.id} className="list-group-item d-flex justify-content-between align-items-center">
+                  <div>
+                    <div className="fw-bold">{t.summary}</div>
+                    <div className="small text-muted">{t.ticketNumber}</div>
+                  </div>
+                  <span className="badge bg-primary">{t.requestedPriority}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-muted italic">No tickets found.</div>
+          )}
+        </section>
+      )}
+
+      {/* Tab Content 2: Create Ticket Screen View Placeholder (Business form implemented in Issue #28) */}
+      {activeTab === "create-ticket" && (
+        <section className="mb-5">
+          <h2 className="h5 mb-3 fw-bold">Create Ticket</h2>
+          <div className="card p-4 text-center bg-light border-dashed">
+            <p className="text-muted mb-0">Create Ticket Form Placeholder (Issue #28)</p>
+          </div>
+        </section>
+      )}
 
       {/* Lab 1 System Check Panel */}
       <section className="border-top pt-4">

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,6 +10,13 @@ export interface SystemStatus {
   categories: Category[];
 }
 
+export interface Requester {
+  id: number;
+  name: string;
+  email: string;
+  isActive?: boolean;
+}
+
 export async function checkSystem(): Promise<SystemStatus> {
   try {
     const healthRes = await fetch(`${API_URL}/api/health`);
@@ -27,4 +34,59 @@ export async function checkSystem(): Promise<SystemStatus> {
   } catch (err) {
     throw new Error("Unable to connect to the server. Please check your connection and try again.");
   }
+}
+
+export async function fetchActiveRequesters(): Promise<Requester[]> {
+  const res = await fetch(`${API_URL}/api/requesters/active`);
+  if (!res.ok) {
+    throw new Error("Unable to load requesters. Please check your connection and try again.");
+  }
+  const data = await res.json();
+  // Filter active requesters if API returns isActive property
+  return Array.isArray(data) ? data.filter((r: Requester) => r.isActive !== false) : [];
+}
+
+export function getSelectedRequesterId(): string | null {
+  return localStorage.getItem("selectedRequesterId");
+}
+
+export function setSelectedRequesterId(id: string | null): void {
+  if (id) {
+    localStorage.setItem("selectedRequesterId", id);
+  } else {
+    localStorage.removeItem("selectedRequesterId");
+  }
+}
+
+export async function fetchWithRequesterContext(url: string, options: RequestInit = {}): Promise<Response> {
+  const requesterId = getSelectedRequesterId();
+  const headers: Record<string, string> = {};
+
+  if (options.headers) {
+    if (options.headers instanceof Headers) {
+      options.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+    } else if (Array.isArray(options.headers)) {
+      options.headers.forEach(([key, value]) => {
+        headers[key] = value;
+      });
+    } else {
+      Object.assign(headers, options.headers);
+    }
+  }
+
+  if (requesterId) {
+    headers["X-Requester-Id"] = requesterId;
+  }
+
+  return fetch(url, { ...options, headers });
+}
+
+export async function fetchMyTickets(): Promise<any> {
+  const res = await fetchWithRequesterContext(`${API_URL}/api/tickets`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch tickets: ${res.status}`);
+  }
+  return res.json();
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -58,8 +58,12 @@ export function setSelectedRequesterId(id: string | null): void {
   }
 }
 
-export async function fetchWithRequesterContext(url: string, options: RequestInit = {}): Promise<Response> {
-  const requesterId = getSelectedRequesterId();
+export async function fetchWithRequesterContext(
+  url: string,
+  options: RequestInit = {},
+  explicitRequesterId?: string
+): Promise<Response> {
+  const requesterId = explicitRequesterId ?? getSelectedRequesterId();
   const headers: Record<string, string> = {};
 
   if (options.headers) {
@@ -77,14 +81,14 @@ export async function fetchWithRequesterContext(url: string, options: RequestIni
   }
 
   if (requesterId) {
-    headers["X-Requester-Id"] = requesterId;
+    headers["X-Requester-Id"] = String(requesterId);
   }
 
   return fetch(url, { ...options, headers });
 }
 
-export async function fetchMyTickets(): Promise<any> {
-  const res = await fetchWithRequesterContext(`${API_URL}/api/tickets`);
+export async function fetchMyTickets(explicitRequesterId?: string): Promise<any> {
+  const res = await fetchWithRequesterContext(`${API_URL}/api/tickets`, {}, explicitRequesterId);
   if (!res.ok) {
     throw new Error(`Failed to fetch tickets: ${res.status}`);
   }

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -196,10 +196,12 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
     });
   });
 
-  describe("5. Requester-Specific Data Refresh", () => {
-    it("refreshes and replaces requester A ticket data with requester B ticket data upon switching context", async () => {
+  describe("5. Requester-Specific Data Refresh & Explicit Context", () => {
+    it("refreshes and replaces requester A ticket data with requester B ticket data upon switching context using explicit X-Requester-Id header", async () => {
       const user = userEvent.setup();
       localStorage.setItem("selectedRequesterId", "1"); // Start as Alice Smith (ID 1)
+
+      const ticketFetchHeaders: string[] = [];
 
       globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
         const headers = init?.headers as Record<string, string> | undefined;
@@ -209,6 +211,7 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
           return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockActiveRequesters) } as Response);
         }
         if (url.includes("/api/tickets")) {
+          if (reqId) ticketFetchHeaders.push(String(reqId));
           if (reqId === "1") {
             return Promise.resolve({
               ok: true,
@@ -234,9 +237,10 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
 
       render(<App />);
 
-      // Verify Alice's ticket is rendered initially
+      // Verify Alice's ticket is rendered initially and header sent is '1'
       await waitFor(() => {
         expect(screen.getByText(/Alice VPN Connection Issue/i)).toBeInTheDocument();
+        expect(ticketFetchHeaders).toContain("1");
       });
 
       // Switch to Bob (ID 2)
@@ -253,10 +257,11 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
       const continueBtn = screen.getByRole("button", { name: /Continue/i });
       await user.click(continueBtn);
 
-      // Verify Bob's ticket replaces Alice's ticket
+      // Verify Bob's ticket replaces Alice's ticket and header sent is '2'
       await waitFor(() => {
         expect(screen.getByText(/Bob Hardware Printer Offline/i)).toBeInTheDocument();
         expect(screen.queryByText(/Alice VPN Connection Issue/i)).not.toBeInTheDocument();
+        expect(ticketFetchHeaders[ticketFetchHeaders.length - 1]).toBe("2");
       });
     });
   });
@@ -307,6 +312,130 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
       expect(screen.getByText("Loading active requesters…")).toBeInTheDocument();
       // Must NOT render the App Shell navigation bar displaying "Current Requester:"
       expect(screen.queryByText(/Current Requester:/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("8. Application Shell Navigation Tabs (docs/lab-02/ui-spec.md §3.1)", () => {
+    it("renders My Tickets and Create Ticket navigation tabs with aria-current='page' on active tab", async () => {
+      const user = userEvent.setup();
+      localStorage.setItem("selectedRequesterId", "1");
+
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockActiveRequesters) } as Response);
+        }
+        if (url.includes("/api/tickets")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ data: [], pagination: { page: 1, pageSize: 10, totalItems: 0, totalPages: 0 } }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      // 1. Initially My Tickets tab is active with aria-current="page"
+      await waitFor(() => {
+        const myTicketsTab = screen.getByRole("button", { name: /^My Tickets$/i });
+        const createTicketTab = screen.getByRole("button", { name: /^Create Ticket$/i });
+
+        expect(myTicketsTab).toBeInTheDocument();
+        expect(createTicketTab).toBeInTheDocument();
+        expect(myTicketsTab).toHaveAttribute("aria-current", "page");
+        expect(createTicketTab).not.toHaveAttribute("aria-current");
+      });
+
+      // 2. Click Create Ticket tab
+      const createTicketTab = screen.getByRole("button", { name: /^Create Ticket$/i });
+      await user.click(createTicketTab);
+
+      // 3. Create Ticket tab becomes active with aria-current="page"
+      const myTicketsTab = screen.getByRole("button", { name: /^My Tickets$/i });
+      expect(createTicketTab).toHaveAttribute("aria-current", "page");
+      expect(myTicketsTab).not.toHaveAttribute("aria-current");
+      expect(screen.getByText(/Create Ticket Form Placeholder/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("9. Concurrency & Stale Response Race Protection", () => {
+    it("discards stale tickets from Alice when Alice's request resolves after Bob's request has already completed", async () => {
+      const user = userEvent.setup();
+      localStorage.setItem("selectedRequesterId", "1"); // Start as Alice (ID 1)
+
+      let resolveAliceTickets!: (value: any) => void;
+
+      globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        const reqId = headers?.["X-Requester-Id"] || (init?.headers instanceof Headers ? init.headers.get("X-Requester-Id") : undefined);
+
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockActiveRequesters) } as Response);
+        }
+        if (url.includes("/api/tickets")) {
+          if (reqId === "1") {
+            // Keep Alice's request pending until manually resolved
+            return new Promise((resolve) => {
+              resolveAliceTickets = resolve;
+            });
+          }
+          if (reqId === "2") {
+            // Resolve Bob's request immediately
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: () => Promise.resolve({
+                data: [{ id: "t2", ticketNumber: "TCK-002", summary: "Bob Hardware Printer Offline", requestedPriority: "LOW", currentStatus: "NEW" }],
+                pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1 },
+              }),
+            } as Response);
+          }
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      // 1. Initial render starts Alice's request (held pending)
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /Change Requester/i })).toBeInTheDocument();
+      });
+
+      // 2. Switch to Bob (ID 2) while Alice's request is still pending
+      const changeBtn = screen.getByRole("button", { name: /Change Requester/i });
+      await user.click(changeBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Bob Jones/i)).toBeInTheDocument();
+      });
+
+      const bobOption = screen.getByLabelText(/Bob Jones/i) || screen.getByText(/Bob Jones/i);
+      await user.click(bobOption);
+
+      const continueBtn = screen.getByRole("button", { name: /Continue/i });
+      await user.click(continueBtn);
+
+      // 3. Bob's request completes first and displays Bob's tickets
+      await waitFor(() => {
+        expect(screen.getByText(/Bob Hardware Printer Offline/i)).toBeInTheDocument();
+      });
+
+      // 4. Resolve Alice's stale request AFTER Bob's request has completed
+      resolveAliceTickets({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          data: [{ id: "t1", ticketNumber: "TCK-001", summary: "Alice Stale VPN Ticket", requestedPriority: "HIGH", currentStatus: "NEW" }],
+          pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1 },
+        }),
+      });
+
+      // 5. Verify Alice's stale ticket response does NOT overwrite Bob's ticket data
+      await waitFor(() => {
+        expect(screen.getByText(/Bob Hardware Printer Offline/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Alice Stale VPN Ticket/i)).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../src/App";
+import * as api from "../../src/api";
+
+const mockActiveRequesters = [
+  { id: 1, name: "Alice Smith", email: "alice@example.com", isActive: true },
+  { id: 2, name: "Bob Jones", email: "bob@example.com", isActive: true },
+  { id: 3, name: "Charlie Brown", email: "charlie@example.com", isActive: true },
+  { id: 4, name: "Diana Prince", email: "diana@example.com", isActive: true },
+];
+
+const mockAllRequestersWithInactive = [
+  ...mockActiveRequesters,
+  { id: 5, name: "Eve Adams", email: "eve@example.com", isActive: false },
+];
+
+describe("Issue #34: Development Requester Selection & Context Suite", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    originalFetch = global.fetch;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    localStorage.clear();
+  });
+
+  describe("1. Inactive Requester Exclusion", () => {
+    it("displays only active requesters and excludes inactive requesters (Eve Adams) from selector UI", async () => {
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(mockActiveRequesters), // Backend API returns only active
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Alice Smith/i)).toBeInTheDocument();
+        expect(screen.getByText(/Bob Jones/i)).toBeInTheDocument();
+        expect(screen.getByText(/Charlie Brown/i)).toBeInTheDocument();
+        expect(screen.getByText(/Diana Prince/i)).toBeInTheDocument();
+      });
+
+      // Assert inactive seed user Eve Adams is NOT rendered or selectable in the DOM
+      expect(screen.queryByText(/Eve Adams/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("2. Invalid Stored Requester Context", () => {
+    it("redirects to Requester Selector when LocalStorage contains an invalid or unknown requester ID", async () => {
+      // Pre-set invalid/unknown requester ID in LocalStorage
+      localStorage.setItem("selectedRequesterId", "9999");
+
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(mockActiveRequesters),
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      await waitFor(() => {
+        // App must NOT silently authorize invalid requester ID "9999"; it must require selector UI
+        expect(screen.getByText(/Select Development Requester|Select Requester/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Continue/i })).toBeInTheDocument();
+      });
+    });
+
+    it("redirects to Requester Selector when LocalStorage contains an inactive requester ID (e.g. Eve Adams ID 5)", async () => {
+      localStorage.setItem("selectedRequesterId", "5");
+
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(mockActiveRequesters),
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Select Development Requester|Select Requester/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Continue/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("3. Valid Stored Requester Access", () => {
+    it("allows direct access to requester-scoped screen without redirect when LocalStorage contains valid active requester ID", async () => {
+      localStorage.setItem("selectedRequesterId", "1"); // Valid active requester Alice Smith
+
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(mockActiveRequesters),
+          } as Response);
+        }
+        if (url.includes("/api/tickets")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ data: [], pagination: { page: 1, pageSize: 10, totalItems: 0, totalPages: 0 } }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      await waitFor(() => {
+        // Valid context allows access to main application shell displaying Alice Smith's identity
+        expect(screen.getByText(/Alice Smith/i)).toBeInTheDocument();
+        // Should NOT show the selector screen Continue submission button
+        expect(screen.queryByRole("button", { name: /^Continue$/i })).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("4. Requester Switching Replaces Context", () => {
+    it("replaces header context and displays new requester identity when switching from Requester A to Requester B", async () => {
+      const user = userEvent.setup();
+      localStorage.setItem("selectedRequesterId", "1"); // Start with Alice (ID 1)
+
+      const fetchCalls: { url: string; headers: any }[] = [];
+
+      global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        fetchCalls.push({ url, headers: init?.headers });
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockActiveRequesters) } as Response);
+        }
+        if (url.includes("/api/tickets")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ data: [], pagination: { page: 1, pageSize: 10, totalItems: 0, totalPages: 0 } }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      // 1. Initially Alice Smith is active
+      await waitFor(() => {
+        expect(screen.getByText(/Alice Smith/i)).toBeInTheDocument();
+      });
+
+      // 2. Click Change Requester
+      const changeBtn = screen.getByRole("button", { name: /Change Requester/i });
+      await user.click(changeBtn);
+
+      // 3. Select Bob Jones (ID 2)
+      await waitFor(() => {
+        expect(screen.getByText(/Bob Jones/i)).toBeInTheDocument();
+      });
+
+      const bobOption = screen.getByLabelText(/Bob Jones/i) || screen.getByText(/Bob Jones/i);
+      await user.click(bobOption);
+
+      const continueBtn = screen.getByRole("button", { name: /Continue/i });
+      await user.click(continueBtn);
+
+      // 4. Verify LocalStorage and Header updated to ID 2 (Bob Jones)
+      expect(localStorage.getItem("selectedRequesterId")).toBe("2");
+
+      await waitFor(() => {
+        expect(screen.getByText(/Bob Jones/i)).toBeInTheDocument();
+        const latestTicketCall = [...fetchCalls].reverse().find((c) => c.url.includes("/api/tickets"));
+        const reqHeader = latestTicketCall?.headers?.["X-Requester-Id"] || (latestTicketCall?.headers instanceof Headers ? latestTicketCall.headers.get("X-Requester-Id") : undefined);
+        expect(reqHeader).toBe("2");
+      });
+    });
+  });
+
+  describe("5. Requester-Specific Data Refresh", () => {
+    it("refreshes and replaces requester A ticket data with requester B ticket data upon switching context", async () => {
+      const user = userEvent.setup();
+      localStorage.setItem("selectedRequesterId", "1"); // Start as Alice Smith (ID 1)
+
+      global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        const headers = init?.headers;
+        const reqId = headers?.["X-Requester-Id"] || (headers instanceof Headers ? headers.get("X-Requester-Id") : undefined);
+
+        if (url.includes("/api/requesters/active")) {
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockActiveRequesters) } as Response);
+        }
+        if (url.includes("/api/tickets")) {
+          if (reqId === "1") {
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: () => Promise.resolve({
+                data: [{ id: "t1", ticketNumber: "TCK-001", summary: "Alice VPN Connection Issue", requestedPriority: "HIGH", currentStatus: "NEW" }],
+                pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1 },
+              }),
+            } as Response);
+          } else if (reqId === "2") {
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: () => Promise.resolve({
+                data: [{ id: "t2", ticketNumber: "TCK-002", summary: "Bob Hardware Printer Offline", requestedPriority: "LOW", currentStatus: "NEW" }],
+                pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1 },
+              }),
+            } as Response);
+          }
+        }
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+      });
+
+      render(<App />);
+
+      // Verify Alice's ticket is rendered initially
+      await waitFor(() => {
+        expect(screen.getByText(/Alice VPN Connection Issue/i)).toBeInTheDocument();
+      });
+
+      // Switch to Bob (ID 2)
+      const changeBtn = screen.getByRole("button", { name: /Change Requester/i });
+      await user.click(changeBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Bob Jones/i)).toBeInTheDocument();
+      });
+
+      const bobOption = screen.getByLabelText(/Bob Jones/i) || screen.getByText(/Bob Jones/i);
+      await user.click(bobOption);
+
+      const continueBtn = screen.getByRole("button", { name: /Continue/i });
+      await user.click(continueBtn);
+
+      // Verify Bob's ticket replaces Alice's ticket
+      await waitFor(() => {
+        expect(screen.getByText(/Bob Hardware Printer Offline/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Alice VPN Connection Issue/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("6. Responsive Viewport & UI Contract (docs/lab-02/ui-spec.md)", () => {
+    const viewports = [
+      { name: "Desktop", width: 1200, height: 900 },
+      { name: "Tablet", width: 768, height: 1024 },
+      { name: "Mobile", width: 375, height: 667 },
+    ];
+
+    viewports.forEach((vp) => {
+      it(`renders accessible and usable requester selection controls on ${vp.name} (${vp.width}px)`, async () => {
+        // Set viewport width & height
+        window.innerWidth = vp.width;
+        window.innerHeight = vp.height;
+        window.dispatchEvent(new Event("resize"));
+
+        global.fetch = vi.fn().mockImplementation((url: string) => {
+          if (url.includes("/api/requesters/active")) {
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: () => Promise.resolve(mockActiveRequesters),
+            } as Response);
+          }
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) } as Response);
+        });
+
+        render(<App />);
+
+        await waitFor(() => {
+          expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+          expect(screen.getByRole("button", { name: /Continue/i })).toBeInTheDocument();
+        });
+      });
+    });
+  });
+});

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -17,22 +17,22 @@ const mockAllRequestersWithInactive = [
 ];
 
 describe("Issue #34: Development Requester Selection & Context Suite", () => {
-  let originalFetch: typeof global.fetch;
+  let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     localStorage.clear();
-    originalFetch = global.fetch;
+    originalFetch = globalThis.fetch;
     vi.restoreAllMocks();
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
+    globalThis.fetch = originalFetch;
     localStorage.clear();
   });
 
   describe("1. Inactive Requester Exclusion", () => {
     it("displays only active requesters and excludes inactive requesters (Eve Adams) from selector UI", async () => {
-      global.fetch = vi.fn().mockImplementation((url: string) => {
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
         if (url.includes("/api/requesters/active")) {
           return Promise.resolve({
             ok: true,
@@ -62,7 +62,7 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
       // Pre-set invalid/unknown requester ID in LocalStorage
       localStorage.setItem("selectedRequesterId", "9999");
 
-      global.fetch = vi.fn().mockImplementation((url: string) => {
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
         if (url.includes("/api/requesters/active")) {
           return Promise.resolve({
             ok: true,
@@ -85,7 +85,7 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
     it("redirects to Requester Selector when LocalStorage contains an inactive requester ID (e.g. Eve Adams ID 5)", async () => {
       localStorage.setItem("selectedRequesterId", "5");
 
-      global.fetch = vi.fn().mockImplementation((url: string) => {
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
         if (url.includes("/api/requesters/active")) {
           return Promise.resolve({
             ok: true,
@@ -109,7 +109,7 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
     it("allows direct access to requester-scoped screen without redirect when LocalStorage contains valid active requester ID", async () => {
       localStorage.setItem("selectedRequesterId", "1"); // Valid active requester Alice Smith
 
-      global.fetch = vi.fn().mockImplementation((url: string) => {
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
         if (url.includes("/api/requesters/active")) {
           return Promise.resolve({
             ok: true,
@@ -145,7 +145,7 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
 
       const fetchCalls: { url: string; headers: any }[] = [];
 
-      global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
         fetchCalls.push({ url, headers: init?.headers });
         if (url.includes("/api/requesters/active")) {
           return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockActiveRequesters) } as Response);
@@ -188,7 +188,9 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
       await waitFor(() => {
         expect(screen.getByText(/Bob Jones/i)).toBeInTheDocument();
         const latestTicketCall = [...fetchCalls].reverse().find((c) => c.url.includes("/api/tickets"));
-        const reqHeader = latestTicketCall?.headers?.["X-Requester-Id"] || (latestTicketCall?.headers instanceof Headers ? latestTicketCall.headers.get("X-Requester-Id") : undefined);
+        const reqHeader = (latestTicketCall?.headers as Record<string, string>)?.[
+          "X-Requester-Id"
+        ] || (latestTicketCall?.headers instanceof Headers ? latestTicketCall.headers.get("X-Requester-Id") : undefined);
         expect(reqHeader).toBe("2");
       });
     });
@@ -199,9 +201,9 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
       const user = userEvent.setup();
       localStorage.setItem("selectedRequesterId", "1"); // Start as Alice Smith (ID 1)
 
-      global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
-        const headers = init?.headers;
-        const reqId = headers?.["X-Requester-Id"] || (headers instanceof Headers ? headers.get("X-Requester-Id") : undefined);
+      globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        const reqId = headers?.["X-Requester-Id"] || (init?.headers instanceof Headers ? init.headers.get("X-Requester-Id") : undefined);
 
         if (url.includes("/api/requesters/active")) {
           return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(mockActiveRequesters) } as Response);
@@ -273,7 +275,7 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
         window.innerHeight = vp.height;
         window.dispatchEvent(new Event("resize"));
 
-        global.fetch = vi.fn().mockImplementation((url: string) => {
+        globalThis.fetch = vi.fn().mockImplementation((url: string) => {
           if (url.includes("/api/requesters/active")) {
             return Promise.resolve({
               ok: true,
@@ -291,6 +293,20 @@ describe("Issue #34: Development Requester Selection & Context Suite", () => {
           expect(screen.getByRole("button", { name: /Continue/i })).toBeInTheDocument();
         });
       });
+    });
+  });
+
+  describe("7. Initial Rendering State & Mount Behavior", () => {
+    it("renders the selection view or loading state on initial mount rather than the App Shell with no current requester", () => {
+      // Mock fetch to return a pending Promise so requester loading stays in progress
+      globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}));
+
+      render(<App />);
+
+      // On initial mount while loading, the app must show loading/selection view
+      expect(screen.getByText("Loading active requesters…")).toBeInTheDocument();
+      // Must NOT render the App Shell navigation bar displaying "Current Requester:"
+      expect(screen.queryByText(/Current Requester:/i)).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Implement development requester selection for Lab 2
- Load and display active requesters only
- Persist selected requester with LocalStorage
- Attach `X-Requester-Id` to requester-scoped API requests
- Display current requester identity in the application shell
- Support requester switching and refresh requester-specific data
- Handle loading, empty, failure, redirect, accessibility, and responsive states

## Testing
- Client tests: 13/13 passed
- Server tests: 71/71 passed
- Client production build: passed
- `git diff --check` passed
- Added regression coverage for the initial requester-selection rendering state.

## Scope
Implements Issue #34 for Lab 2.

No authentication, JWT, password, session, Lab 3 authorization, or unrelated features were added.